### PR TITLE
feat: add tool call logs for workflow agent

### DIFF
--- a/src/backend/bisheng/api/services/workflow.py
+++ b/src/backend/bisheng/api/services/workflow.py
@@ -1,29 +1,28 @@
 from typing import Dict, Optional
 
-from bisheng.utils import generate_uuid
-from fastapi.encoders import jsonable_encoder
-from langchain.memory import ConversationBufferWindowMemory
-
 from bisheng.api.errcode.base import NotFoundError, UnAuthorizedError
 from bisheng.api.errcode.flow import WorkFlowInitError
 from bisheng.api.services.base import BaseService
 from bisheng.api.services.user_service import UserPayload
+from bisheng.api.v1.schema.workflow import (WorkflowEvent, WorkflowEventType, WorkflowInputItem,
+                                            WorkflowInputSchema, WorkflowOutputSchema)
 from bisheng.api.v1.schemas import ChatResponse
-from bisheng.api.v1.schema.workflow import WorkflowEvent, WorkflowEventType, WorkflowInputSchema, WorkflowInputItem, \
-    WorkflowOutputSchema
 from bisheng.chat.utils import SourceType
-from bisheng.database.models.flow import FlowDao, FlowType, FlowStatus
+from bisheng.database.models.flow import FlowDao, FlowStatus, FlowType
 from bisheng.database.models.flow_version import FlowVersionDao
 from bisheng.database.models.group_resource import GroupResourceDao, ResourceTypeEnum
 from bisheng.database.models.role_access import AccessType, RoleAccessDao
 from bisheng.database.models.tag import TagDao
 from bisheng.database.models.user import UserDao
 from bisheng.database.models.user_role import UserRoleDao
+from bisheng.utils import generate_uuid
 from bisheng.workflow.callback.base_callback import BaseCallback
 from bisheng.workflow.common.node import BaseNodeData, NodeType
 from bisheng.workflow.graph.graph_state import GraphState
 from bisheng.workflow.graph.workflow import Workflow
 from bisheng.workflow.nodes.node_manage import NodeFactory
+from fastapi.encoders import jsonable_encoder
+from langchain.memory import ConversationBufferWindowMemory
 
 
 class WorkFlowService(BaseService):
@@ -223,6 +222,11 @@ class WorkFlowService(BaseService):
                     output_key=chat_response.message.get('output_key'),
                 )
                 cls.handle_source(chat_response, workflow_event)
+            case WorkflowEventType.ToolCall.value:
+                workflow_event.status = chat_response.type
+                workflow_event.output_schema = WorkflowOutputSchema(
+                    message=chat_response.message
+                )
             case WorkflowEventType.Error.value:
                 workflow_event.event = WorkflowEventType.Close.value
                 workflow_event.output_schema = WorkflowOutputSchema(

--- a/src/backend/bisheng/api/v1/schema/workflow.py
+++ b/src/backend/bisheng/api/v1/schema/workflow.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Any, List
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -16,6 +16,7 @@ class WorkflowEventType(Enum):
     OutputWithChoose = 'output_with_choose_msg'
     # OutputWithChoose = 'output_choose_msg'
     StreamMsg = 'stream_msg'
+    ToolCall = 'tool_call'
     Close = 'close'
     Error = 'error'
 

--- a/src/backend/bisheng/worker/workflow/redis_callback.py
+++ b/src/backend/bisheng/worker/workflow/redis_callback.py
@@ -5,25 +5,26 @@ import time
 import uuid
 from typing import AsyncIterator
 
-from cachetools import TTLCache
-from langchain_core.documents import Document
-from loguru import logger
-
-from bisheng.api.errcode.flow import WorkFlowNodeRunMaxTimesError, WorkFlowWaitUserTimeoutError, \
-    WorkFlowNodeUpdateError, WorkFlowVersionUpdateError, WorkFlowTaskBusyError
+from bisheng.api.errcode.flow import (WorkFlowNodeRunMaxTimesError, WorkFlowNodeUpdateError,
+                                      WorkFlowTaskBusyError, WorkFlowVersionUpdateError,
+                                      WorkFlowWaitUserTimeoutError)
 from bisheng.api.v1.schema.workflow import WorkflowEventType
 from bisheng.api.v1.schemas import ChatResponse
 from bisheng.cache.redis import redis_client
 from bisheng.chat.utils import sync_judge_source, sync_process_source_document
 from bisheng.database.models.flow import FlowDao, FlowType
-from bisheng.database.models.message import ChatMessageDao, ChatMessage
-from bisheng.database.models.session import MessageSessionDao, MessageSession
+from bisheng.database.models.message import ChatMessage, ChatMessageDao
+from bisheng.database.models.session import MessageSession, MessageSessionDao
 from bisheng.settings import settings
 from bisheng.workflow.callback.base_callback import BaseCallback
-from bisheng.workflow.callback.event import NodeStartData, NodeEndData, UserInputData, GuideWordData, GuideQuestionData, \
-    OutputMsgData, StreamMsgData, StreamMsgOverData, OutputMsgChooseData, OutputMsgInputData
+from bisheng.workflow.callback.event import (GuideQuestionData, GuideWordData, NodeEndData,
+                                             NodeStartData, OutputMsgChooseData, OutputMsgData,
+                                             OutputMsgInputData, StreamMsgData, StreamMsgOverData,
+                                             ToolCallData, UserInputData)
 from bisheng.workflow.common.workflow import WorkflowStatus
-
+from cachetools import TTLCache
+from langchain_core.documents import Document
+from loguru import logger
 
 
 class RedisCallback(BaseCallback):
@@ -82,14 +83,15 @@ class RedisCallback(BaseCallback):
 
     def get_workflow_response(self) -> ChatResponse | None:
         response = self.redis_client.lpop(self.workflow_event_key)
-        if response:
-            response = ChatResponse(**json.loads(response))
-            if ((response.category == WorkflowEventType.NodeRun.value and response.type == 'end'
-                 and response.message and response.message.get('node_id', '').startswith('end_')) or
-                    (response.category in [WorkflowEventType.UserInput.value, WorkflowEventType.OutputWithChoose.value
-                        , WorkflowEventType.OutputWithInput.value])):
-                # 如果是结束节点或者输入事件，清空状态缓存
-                self.workflow_cache.clear()
+            if response:
+                response = ChatResponse(**json.loads(response))
+                if ((response.category == WorkflowEventType.NodeRun.value and response.type == 'end'
+                     and response.message and response.message.get('node_id', '').startswith('end_')) or
+                        (response.category in [WorkflowEventType.UserInput.value,
+                                               WorkflowEventType.OutputWithChoose.value,
+                                               WorkflowEventType.OutputWithInput.value])):
+                    # 如果是结束节点或者输入事件，清空状态缓存
+                    self.workflow_cache.clear()
         return response
 
     def build_chat_response(self, category, category_type, message, extra=None, files=None):
@@ -374,7 +376,7 @@ class RedisCallback(BaseCallback):
         logger.debug(f'stream over: {data}')
         # 替换掉minio的share前缀，通过nginx转发  ugly solve
         minio_share = settings.get_minio_conf().sharepoint
-        data.msg = data.msg.replace(f"http://{minio_share}", "")
+        data.msg = data.msg.replace(f'http://{minio_share}', '')
         chat_response = ChatResponse(message=data.dict(exclude={'source_documents'}),
                                      category=WorkflowEventType.StreamMsg.value,
                                      extra='',
@@ -412,4 +414,13 @@ class RedisCallback(BaseCallback):
         msg_id = self.save_chat_message(chat_response, source_documents=data.source_documents)
         if msg_id:
             chat_response.message_id = msg_id
+        self.send_chat_response(chat_response)
+
+    def on_tool_call(self, data: ToolCallData):
+        logger.debug(f'tool call: {data}')
+        chat_response = ChatResponse(message=data.dict(),
+                                     category=WorkflowEventType.ToolCall.value,
+                                     type=data.status,
+                                     flow_id=self.workflow_id,
+                                     chat_id=self.chat_id)
         self.send_chat_response(chat_response)

--- a/src/backend/bisheng/workflow/callback/base_callback.py
+++ b/src/backend/bisheng/workflow/callback/base_callback.py
@@ -1,8 +1,9 @@
 from abc import ABC
 
-from bisheng.workflow.callback.event import NodeStartData, NodeEndData, OutputMsgChooseData, OutputMsgInputData, \
-    UserInputData, GuideWordData, GuideQuestionData, \
-    OutputMsgData, StreamMsgData, StreamMsgOverData
+from bisheng.workflow.callback.event import (GuideQuestionData, GuideWordData, NodeEndData,
+                                             NodeStartData, OutputMsgChooseData, OutputMsgData,
+                                             OutputMsgInputData, StreamMsgData, StreamMsgOverData,
+                                             ToolCallData, UserInputData)
 
 
 class BaseCallback(ABC):
@@ -43,4 +44,7 @@ class BaseCallback(ABC):
         pass
 
     def on_output_input(self, data: OutputMsgInputData):
+        pass
+
+    def on_tool_call(self, data: ToolCallData):
         pass

--- a/src/backend/bisheng/workflow/callback/event.py
+++ b/src/backend/bisheng/workflow/callback/event.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Dict
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -64,3 +64,14 @@ class StreamMsgData(BaseModel):
 
 class StreamMsgOverData(StreamMsgData):
     source_documents: Optional[List[Any]] = Field(default=[], description='Source documents')
+
+
+class ToolCallData(BaseModel):
+    unique_id: str = Field(..., description='Unique execution id')
+    node_id: str = Field(..., description='Node unique id')
+    run_id: str = Field(..., description='Tool run id')
+    name: str = Field(..., description='Tool name')
+    status: str = Field(..., description='Tool call status')
+    input: Optional[str] = Field(None, description='Tool input')
+    output: Optional[str] = Field(None, description='Tool output')
+    error: Optional[str] = Field(None, description='Tool error message')

--- a/src/backend/bisheng/workflow/callback/llm_callback.py
+++ b/src/backend/bisheng/workflow/callback/llm_callback.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, Optional, List, Union
-from uuid import UUID
+from typing import Any, Dict, List, Optional, Union
 
 from bisheng.workflow.callback.base_callback import BaseCallback
-from bisheng.workflow.callback.event import OutputMsgData, StreamMsgData, StreamMsgOverData
-from langchain_core.callbacks.base import AsyncCallbackHandler, BaseCallbackHandler
+from bisheng.workflow.callback.event import (OutputMsgData, StreamMsgData, StreamMsgOverData,
+                                             ToolCallData)
+from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.outputs import LLMResult
 from loguru import logger
 
@@ -39,13 +39,20 @@ class LLMNodeCallbackHandler(BaseCallbackHandler):
         """Run when tool starts running."""
         logger.debug(
             f'on_tool_start  serialized={serialized} input_str={input_str} kwargs={kwargs}')
+        run_id = kwargs.get('run_id').hex
         if self.tool_list is not None:
             self.tool_list.append({
                 'type': 'start',
-                'run_id': kwargs.get('run_id').hex,
+                'run_id': run_id,
                 'name': serialized['name'],
                 'input': input_str,
             })
+        self.callback_manager.on_tool_call(ToolCallData(unique_id=self.unique_id,
+                                                        node_id=self.node_id,
+                                                        run_id=run_id,
+                                                        name=serialized['name'],
+                                                        status='start',
+                                                        input=input_str))
         if serialized['name'] == 'sql_agent':
             self.output = False
 
@@ -53,13 +60,20 @@ class LLMNodeCallbackHandler(BaseCallbackHandler):
         """Run when tool ends running."""
         logger.debug(f'on_tool_end  output={output} kwargs={kwargs}')
         result = output if isinstance(output, str) else getattr(output, 'content', output)
+        run_id = kwargs.get('run_id').hex
         if self.tool_list is not None:
             self.tool_list.append({
                 'type': 'end',
-                'run_id': kwargs.get('run_id').hex,
+                'run_id': run_id,
                 'name': kwargs['name'],
                 'output': result,
             })
+        self.callback_manager.on_tool_call(ToolCallData(unique_id=self.unique_id,
+                                                        node_id=self.node_id,
+                                                        run_id=run_id,
+                                                        name=kwargs['name'],
+                                                        status='end',
+                                                        output=result))
         if kwargs['name'] == 'sql_agent':
             self.output = True
 
@@ -67,12 +81,19 @@ class LLMNodeCallbackHandler(BaseCallbackHandler):
                             **kwargs: Any) -> Any:
         """Run when tool errors."""
         logger.debug(f'on_tool_error error={error} kwargs={kwargs}')
+        run_id = kwargs.get('run_id').hex
         if self.tool_list is not None:
             self.tool_list.append({
                 'type': 'error',
-                'run_id': kwargs.get('run_id').hex,
+                'run_id': run_id,
                 'error': str(error),
             })
+        self.callback_manager.on_tool_call(ToolCallData(unique_id=self.unique_id,
+                                                        node_id=self.node_id,
+                                                        run_id=run_id,
+                                                        name=kwargs.get('name', ''),
+                                                        status='error',
+                                                        error=str(error)))
         if kwargs['name'] == 'sql_agent':
             self.output = True
 

--- a/src/frontend/platform/src/pages/BuildPage/flow/FlowChat/ChatMessages.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/flow/FlowChat/ChatMessages.tsx
@@ -13,6 +13,7 @@ import InputForm from "./InputForm";
 import MessageBs from "./MessageBs";
 import MessageBsChoose from "./MessageBsChoose";
 import MessageNodeRun from "./MessageNodeRun";
+import MessageToolCall from "./MessageToolCall";
 import { useMessageStore } from "./messageStore";
 import MessageUser from "./MessageUser";
 
@@ -152,6 +153,8 @@ export default function ChatMessages({
                         return <MessageBsChoose type='input' key={msg.message_id} data={msg} logo={logo} />;
                     case 'node_run':
                         return <MessageNodeRun key={msg.message_id} data={msg} />;
+                    case 'tool_call':
+                        return <MessageToolCall key={msg.message_id} data={msg} index={index} />;
                     default:
                         return <div className="text-sm mt-2 border rounded-md p-2" key={msg.message_id}>Unknown message type</div>;
                 }

--- a/src/frontend/platform/src/pages/BuildPage/flow/FlowChat/MessageToolCall.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/flow/FlowChat/MessageToolCall.tsx
@@ -1,0 +1,42 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/bs-ui/accordion";
+import { Badge } from "@/components/bs-ui/badge";
+import { WorkflowMessage } from "@/types/flow";
+
+export default function MessageToolCall({ data, index }: { data: WorkflowMessage; index: number }) {
+    const { message } = data as any;
+    const status = data.end ? (message.error ? "Error" : "Success") : "Running";
+
+    return (
+        <div className="py-1">
+            <Accordion type="single" collapsible>
+                <AccordionItem value={message.run_id} className="border rounded-md">
+                    <AccordionTrigger className="px-4 py-2 flex items-center gap-2 text-sm">
+                        <span className="font-bold">{index + 1}. {message.name}</span>
+                        <Badge variant={status === 'Error' ? 'destructive' : status === 'Success' ? 'secondary' : 'outline'}>{status}</Badge>
+                    </AccordionTrigger>
+                    <AccordionContent className="px-4 py-2 text-sm space-y-2">
+                        {message.input && (
+                            <div>
+                                <div className="text-xs text-muted-foreground mb-1">Request</div>
+                                <pre className="bg-muted p-2 rounded whitespace-pre-wrap overflow-x-auto">{message.input}</pre>
+                            </div>
+                        )}
+                        {message.output && (
+                            <div>
+                                <div className="text-xs text-muted-foreground mb-1">Response</div>
+                                <pre className="bg-muted p-2 rounded whitespace-pre-wrap overflow-x-auto">{message.output}</pre>
+                            </div>
+                        )}
+                        {message.error && (
+                            <div>
+                                <div className="text-xs text-muted-foreground mb-1">Error</div>
+                                <pre className="bg-muted p-2 rounded whitespace-pre-wrap overflow-x-auto text-red-500">{message.error}</pre>
+                            </div>
+                        )}
+                    </AccordionContent>
+                </AccordionItem>
+            </Accordion>
+        </div>
+    );
+}
+

--- a/src/frontend/platform/src/pages/BuildPage/flow/FlowChat/messageStore.ts
+++ b/src/frontend/platform/src/pages/BuildPage/flow/FlowChat/messageStore.ts
@@ -59,7 +59,7 @@ const handleHistoryMsg = (data: any[]): ChatMessageType[] => {
         .replace(/'/g, '"');                    // 将单引号替换为双引号
 
     return data.filter(item =>
-        ["question", "output_with_input_msg", "output_with_choose_msg", "stream_msg", "output_msg", "guide_question", "guide_word", "node_run", "answer"].includes(item.category)
+        ["question", "output_with_input_msg", "output_with_choose_msg", "stream_msg", "output_msg", "guide_question", "guide_word", "node_run", "answer", "tool_call"].includes(item.category)
         && (item.message || item.reasoning_log)).map(item => {
             let { message, files, is_bot, intermediate_steps, category, ...other } = item
             try {
@@ -68,10 +68,11 @@ const handleHistoryMsg = (data: any[]): ChatMessageType[] => {
                 // 未考虑的情况暂不处理
                 console.error('消息 to JSON error :>> ', e);
             }
+            const chatKey = typeof message === 'string' || category === 'tool_call' ? undefined : Object.keys(message)[0]
             return {
                 ...other,
                 category,
-                chatKey: typeof message === 'string' ? undefined : Object.keys(message)[0],
+                chatKey,
                 end: true,
                 files: files ? JSON.parse(files) : [],
                 isSend: !is_bot,
@@ -105,6 +106,32 @@ export const useMessageStore = create<State & Actions>((set, get) => ({
             // 删除与历史消息中message_id相同的消息,则删除
             const messageId = message_id || (category === "guide_word" ? generateUUID(4) : '') // 后端没给,临时生成一个
             newChat = newChat.filter((item => !(item.message_id === message_id && item.his)))
+            if (category === 'tool_call') {
+                const runId = message.run_id
+                const idx = newChat.findIndex(msg => msg.category === 'tool_call' && msg.message.run_id === runId)
+                if (idx > -1) {
+                    newChat[idx] = {
+                        ...newChat[idx],
+                        message: { ...newChat[idx].message, ...message },
+                        end: type !== 'start'
+                    }
+                } else {
+                    newChat.push({
+                        category, flow_id, chat_id,
+                        message_id: runId,
+                        files, is_bot,
+                        message, receiver, source, user_id,
+                        liked: !!liked,
+                        end: type !== 'start',
+                        sender: '',
+                        node_id: message?.node_id || '',
+                        create_time: formatDate(new Date(), 'yyyy-MM-ddTHH:mm:ss'),
+                        extra,
+                        reasoning_log
+                    })
+                }
+                return { messages: newChat }
+            }
             newChat.push({
                 category, flow_id, chat_id,
                 message_id: messageId,


### PR DESCRIPTION
## Summary
- support ToolCallData callbacks and workflow event type for agent tools
- stream tool call logs through Redis callback to frontend
- render tool call logs in workflow chat with collapsible panels

## Testing
- `pre-commit run --files src/backend/bisheng/workflow/callback/event.py src/backend/bisheng/workflow/callback/base_callback.py src/backend/bisheng/workflow/callback/llm_callback.py src/backend/bisheng/worker/workflow/redis_callback.py src/backend/bisheng/api/v1/schema/workflow.py`
- `pytest` *(fails: TypeError: 'int' object is not subscriptable)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68906d0d45b8832a8022952c65245066